### PR TITLE
fix(types->portal): fixed type inside a constructor for BedrockPortal class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ export class BedrockPortal extends TypedEmitter<PortalEvents> {
 
   public server = new Server()
 
-  constructor(options: Partial<BedrockPortalOptions> = {}) {
+  constructor(options: Partial<BedrockPortalOptions & { world?: Partial<BedrockPortalOptions["world"]> }> = {}) {
     super()
 
     this.options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ export class BedrockPortal extends TypedEmitter<PortalEvents> {
 
   public server = new Server()
 
-  constructor(options: Partial<BedrockPortalOptions & { world?: Partial<BedrockPortalOptions["world"]> }> = {}) {
+  constructor(options: Partial<Omit<BedrockPortalOptions, "world"> & { world?: Partial<BedrockPortalOptions["world"]> }> = {}) {
     super()
 
     this.options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ export class BedrockPortal extends TypedEmitter<PortalEvents> {
 
   public server = new Server()
 
-  constructor(options: Partial<Omit<BedrockPortalOptions, "world"> & { world?: Partial<BedrockPortalOptions["world"]> }> = {}) {
+  constructor(options: Partial<Omit<BedrockPortalOptions, 'world'> & { world?: Partial<BedrockPortalOptions['world']> }> = {}) {
     super()
 
     this.options = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"target": "ES2023",
-    "moduleResolution": "Node",
-    "module": "CommonJS",
+        "moduleResolution": "Node",
+        "module": "CommonJS",
 		"outDir": "./dist",
 		"strict": true,
 		"sourceMap": false,


### PR DESCRIPTION
Previous implementation forced developers to provide entire data of a world inside of constructor of a class `BedrockPortal`, while each property has their own default value. This PR is removing requirement of providing all fields.